### PR TITLE
Implement timeout for excessive processing time

### DIFF
--- a/src/main/webapp/saveScorecardButton.html
+++ b/src/main/webapp/saveScorecardButton.html
@@ -7,7 +7,7 @@
 </span>
 
 <button ng-click="saveScorecard()"
-  ng-show="!uploadDisplay.isLoading && !errorData.getJsonDataError && !ngFileUploadError"
+  ng-show="!uploadDisplay.isLoading && !errorData.getJsonDataError && !ngFileUploadError && !timeoutData.errorMessage"
   type="button" class="btn btn-primary saveResultsBtn" id="saveScorecardButton">Save
   Results
 </button>

--- a/src/main/webapp/scorecard.html
+++ b/src/main/webapp/scorecard.html
@@ -25,11 +25,14 @@
             <h3 ng-show="ngFileUploadError" class="fileUploadError">
               <span class="errorColor">File Upload Error:&nbsp;</span>{{uploadErrorData.uploadError}}
             </h3>
+            <h3 ng-show="timeoutData.errorMessage" class="webServiceError">
+              <span class="errorColor">Timeout Error:&nbsp;</span>{{timeoutData.errorMessage}}
+            </h3>
           </div>
                     
           <debug></debug>
           
-          <span ng-hide="errorData.getJsonDataError || ngFileUploadError">
+          <span ng-hide="errorData.getJsonDataError || ngFileUploadError || timeoutData.errorMessage">
             <top-level-results></top-level-results>          
             <detailed-results></detailed-results>
           </span>          


### PR DESCRIPTION
The timeout is set to 5 minutes when a document is being processed by the scorecard. After this time has passed, if valid data has not been returned, a related error message will be displayed and the service call will be aborted.